### PR TITLE
Update schema for TEST-GREEN

### DIFF
--- a/config/Migrations/20160324054602_Initial.php
+++ b/config/Migrations/20160324054602_Initial.php
@@ -15,12 +15,12 @@ class Initial extends AbstractMigration
             ->addColumn('from_name', 'string', [
                 'default' => null,
                 'limit'   => 255,
-                'null'    => false,
+                'null'    => true,
             ])
             ->addColumn('from_email', 'string', [
                 'default' => null,
                 'limit'   => 255,
-                'null'    => false,
+                'null'    => true,
             ])
             ->addColumn('subject', 'string', [
                 'default' => null,

--- a/config/Schema/schema.sql
+++ b/config/Schema/schema.sql
@@ -2,8 +2,8 @@ DROP TABLE IF EXISTS `email_queue`;
 CREATE TABLE IF NOT EXISTS `email_queue` (
   `id` char(36) CHARACTER SET ascii NOT NULL,
   `email` varchar(129) NOT NULL,
-  `from_name` varchar(255) NOT NULL,
-  `from_email` varchar(255) NOT NULL,
+  `from_name` varchar(255),
+  `from_email` varchar(255),
   `subject` varchar(255) NOT NULL,
   `config` varchar(30) NOT NULL,
   `template` varchar(50) NOT NULL,

--- a/tests/Fixture/EmailQueueFixture.php
+++ b/tests/Fixture/EmailQueueFixture.php
@@ -19,6 +19,8 @@ class EmailQueueFixture extends TestFixture
     public $fields = array(
         'id' => array('type' => 'uuid', 'null' => false),
         'email' => array('type' => 'string', 'null' => false, 'default' => null, 'length' => 100, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
+        'from_name' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 100, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
+        'from_email' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 100, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
         'subject' => array('type' => 'string', 'null' => false, 'default' => null, 'length' => 255, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
         'config' => array('type' => 'string', 'null' => false, 'default' => null, 'length' => 30, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
         'template' => array('type' => 'string', 'null' => false, 'default' => null, 'length' => 50, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
@@ -44,6 +46,8 @@ class EmailQueueFixture extends TestFixture
         array(
             'id' => 'email-1',
             'email' => 'example@example.com',
+            'from_name' => null,
+            'from_email' => null,
             'subject' => 'Free dealz',
             'config' => 'default',
             'template' => 'default',
@@ -61,6 +65,8 @@ class EmailQueueFixture extends TestFixture
         array(
             'id' => 'email-2',
             'email' => 'example2@example.com',
+            'from_name' => null,
+            'from_email' => null,
             'subject' => 'Free dealz',
             'config' => 'default',
             'template' => 'default',
@@ -78,6 +84,8 @@ class EmailQueueFixture extends TestFixture
         array(
             'id' => 'email-3',
             'email' => 'example3@example.com',
+            'from_name' => null,
+            'from_email' => null,
             'subject' => 'Free dealz',
             'config' => 'default',
             'template' => 'default',
@@ -95,6 +103,8 @@ class EmailQueueFixture extends TestFixture
         array(
             'id' => 'email-4',
             'email' => 'example@example.com',
+            'from_name' => null,
+            'from_email' => null,
             'subject' => 'Free dealz',
             'config' => 'default',
             'template' => 'default',
@@ -112,6 +122,8 @@ class EmailQueueFixture extends TestFixture
         array(
             'id' => 'email-5',
             'email' => 'example@example.com',
+            'from_name' => null,
+            'from_email' => null,
             'subject' => 'Free dealz',
             'config' => 'default',
             'template' => 'default',
@@ -129,6 +141,8 @@ class EmailQueueFixture extends TestFixture
         array(
             'id' => 'email-6',
             'email' => 'example@example.com',
+            'from_name' => null,
+            'from_email' => null,
             'subject' => 'Free dealz',
             'config' => 'default',
             'template' => 'default',

--- a/tests/TestCase/Model/Table/EmailQueueTest.php
+++ b/tests/TestCase/Model/Table/EmailQueueTest.php
@@ -51,9 +51,11 @@ class EmailQueueTest extends TestCase
             'template_vars' => array('a' => 'variable', 'some' => 'thing'),
             'sent' => false,
             'locked' => false,
-            'send_tries' => '0',
+            'send_tries' => 0,
             'config' => 'default',
             'headers' => array('X-FOO' => 'bar', 'X-BAZ' => 'thing'),
+            'from_name' => null,
+            'from_email' => null
         );
         $sendAt = new Time($result['send_at']);
         unset($result['id'], $result['created'], $result['modified'], $result['send_at']);


### PR DESCRIPTION
Maybe, `from_name` and `from_email` is not required ( see https://github.com/lorenzo/cakephp-email-queue/blob/master/src/Shell/SenderShell.php#L75 ).
So, I update schema for TEST-GREEN.
