### PR TITLE
i18n handling

### DIFF
--- a/src/Shell/SenderShell.php
+++ b/src/Shell/SenderShell.php
@@ -70,8 +70,9 @@ class SenderShell extends Shell
             $headers = empty($e->headers) ? array() : (array) $e->headers;
             $theme = empty($e->theme) ? '' : (string) $e->theme;
             
-            if (!empty($e->template_vars['language']))
-                I18n::locale($e->template_vars['language']);
+            if (!empty($e->template_vars['locale'])) {
+                I18n::locale($e->template_vars['locale']);
+            }
 
             try {
                 $email = $this->_newEmail($configName);

--- a/src/Shell/SenderShell.php
+++ b/src/Shell/SenderShell.php
@@ -8,6 +8,7 @@ use Cake\ORM\TableRegistry;
 use EmailQueue\Model\Table\EmailQueueTable;
 use Cake\Network\Exception\SocketException;
 use Cake\Mailer\Email;
+use Emojione\Emojione;
 
 class SenderShell extends Shell
 {
@@ -81,6 +82,18 @@ class SenderShell extends Shell
                 if ($transport && $transport->config('additionalParameters')) {
                     $from = key($email->from());
                     $transport->config(['additionalParameters' => "-f $from"]);
+                }
+
+                // emojione
+                if (!empty($e->template_vars)) {
+                    foreach ($e->template_vars as $i => $v) {
+                        $emojione = new Emojione;
+                        $client = $emojione->getClient();
+                        $client->unicodeAlt = true;
+                        $client->imageType = 'svg';
+                        $client->ascii = true;
+                        $e->template_vars[$i] = $client->shortnameToUnicode($v);
+                    }
                 }
 
                 $sent = $email

--- a/src/Shell/SenderShell.php
+++ b/src/Shell/SenderShell.php
@@ -8,7 +8,6 @@ use Cake\ORM\TableRegistry;
 use EmailQueue\Model\Table\EmailQueueTable;
 use Cake\Network\Exception\SocketException;
 use Cake\Mailer\Email;
-use Emojione\Emojione;
 
 class SenderShell extends Shell
 {
@@ -82,18 +81,6 @@ class SenderShell extends Shell
                 if ($transport && $transport->config('additionalParameters')) {
                     $from = key($email->from());
                     $transport->config(['additionalParameters' => "-f $from"]);
-                }
-
-                // emojione
-                if (!empty($e->template_vars)) {
-                    foreach ($e->template_vars as $i => $v) {
-                        $emojione = new Emojione;
-                        $client = $emojione->getClient();
-                        $client->unicodeAlt = true;
-                        $client->imageType = 'svg';
-                        $client->ascii = true;
-                        $e->template_vars[$i] = $client->shortnameToUnicode($v);
-                    }
                 }
 
                 $sent = $email

--- a/src/Shell/SenderShell.php
+++ b/src/Shell/SenderShell.php
@@ -8,6 +8,7 @@ use Cake\ORM\TableRegistry;
 use EmailQueue\Model\Table\EmailQueueTable;
 use Cake\Network\Exception\SocketException;
 use Cake\Mailer\Email;
+use Cake\I18n\I18n;
 
 class SenderShell extends Shell
 {
@@ -68,6 +69,9 @@ class SenderShell extends Shell
             $layout = $e->layout === 'default' ? $this->params['layout'] : $e->layout;
             $headers = empty($e->headers) ? array() : (array) $e->headers;
             $theme = empty($e->theme) ? '' : (string) $e->theme;
+            
+            if (!empty($e->template_vars['language']))
+                I18n::locale($e->template_vars['language']);
 
             try {
                 $email = $this->_newEmail($configName);


### PR DESCRIPTION
usage:
add **'language' => "pl_PL"** to the **$data** parameter

i.e.:

        $data = [
            'sender' => $sender->name,
            'senderId' => $sender->id,
            'receiver' => $friend->username,
            'receiverId' => $friend_id,
            'language' => "pl_PL",
            'message' => "some message"
        ];

        $options = [
            'subject' => $sender->name,
            'send_at' => new FrozenTime('now'),
            'template' => 'some_template',
            'layout' => 'some_layout',
            'format' => 'html',
            'headers' => [],
            'theme' => '',
            'config' => 'some_cfg',
        ];

        EmailQueue::enqueue("some@email.adr", $data, $options);