### PR TITLE
Change email_queue.template_vars to longtext.

### DIFF
--- a/config/Migrations/20190610024410_AlterTemplateVarsToEmailQueue.php
+++ b/config/Migrations/20190610024410_AlterTemplateVarsToEmailQueue.php
@@ -1,0 +1,45 @@
+<?php
+use Migrations\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+class AlterTemplateVarsToEmailQueue extends AbstractMigration
+{
+
+    /**
+     * Up Method
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-up-method
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->table('email_queue')
+            ->changeColumn('template_vars', 'text', [
+                'limit' => MysqlAdapter::TEXT_LONG,
+                'default' => null,
+                'null' => false,
+            ])
+            ->update();
+    }
+
+    /**
+     * Down Method
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-down-method
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->table('email_queue')
+            ->changeColumn('template_vars', 'text', [
+                'limit' => null,
+                'default' => null,
+                'null' => false,
+            ])
+            ->update();
+    }
+}


### PR DESCRIPTION
issue #31

### TODO

- [x] migrate success.
```
[vagrant@localhost vagrant]$ php app/bin/cake.php migrations migrate --plugin EmailQueue

Welcome to CakePHP v3.3.10 Console
---------------------------------------------------------------
App : src
Path: /vagrant/app/src/
PHP : 7.0.33
---------------------------------------------------------------
using migration path /vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Migrations
using seed path /vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Seeds
using environment default
using adapter mysql
using database test

 == 20190610024410 AlterTemplateVarsToEmailQueue: migrating
 == 20190610024410 AlterTemplateVarsToEmailQueue: migrated 0.0231s

All Done. Took 0.0660s
using migration path /vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Migrations
using seed path /vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Seeds
Writing dump file `/vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Migrations/schema-dump-default.lock`...
Dump file `/vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Migrations/schema-dump-default.lock` was successfully written
[vagrant@localhost vagrant]$
```
- [x] rollback success.
```
[vagrant@localhost vagrant]$ php app/bin/cake.php migrations rollback --plugin EmailQueue

Welcome to CakePHP v3.3.10 Console
---------------------------------------------------------------
App : src
Path: /vagrant/app/src/
PHP : 7.0.33
---------------------------------------------------------------
using migration path /vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Migrations
using seed path /vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Seeds
using environment default
using adapter mysql
using database test

 == 20190610024410 AlterTemplateVarsToEmailQueue: reverting
 == 20190610024410 AlterTemplateVarsToEmailQueue: reverted 0.0212s

All Done. Took 0.0829s
using migration path /vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Migrations
using seed path /vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Seeds
Writing dump file `/vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Migrations/schema-dump-default.lock`...
Dump file `/vagrant/app/vendor/lorenzo/cakephp-email-queue/config/Migrations/schema-dump-default.lock` was successfully written
[vagrant@localhost vagrant]$ 
```