### PR TITLE
Added: alter template column so it can accept longer template path

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ and queue a new one by storing the correct data:
 - Third arguments is an array of options, possible options are
  * `subject`: Email's subject
  * `send_at`: date time sting representing the time this email should be sent at (in UTC)
- * `template`:  the name of the element to use as template for the email message
+ * `template`:  the name of the element to use as template for the email message. (maximum supported length is 100 chars)
  * `layout`: the name of the layout to be used to wrap email message
  * `format`: Type of template to use (html, text or both)
  * `headers`: A key-value list of headers to send in the email

--- a/config/Migrations/20190814000000_AlterTemplateToEmailQueue.php
+++ b/config/Migrations/20190814000000_AlterTemplateToEmailQueue.php
@@ -16,7 +16,7 @@ class AlterTemplateToEmailQueue extends AbstractMigration
     {
         $this->table('email_queue')
             ->changeColumn('template', 'string', [
-                'limit' => 255,
+                'limit' => 100,
             ])
             ->update();
     }

--- a/config/Migrations/20190814000000_AlterTemplateToEmailQueue.php
+++ b/config/Migrations/20190814000000_AlterTemplateToEmailQueue.php
@@ -1,0 +1,40 @@
+<?php
+use Migrations\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+class AlterTemplateToEmailQueue extends AbstractMigration
+{
+    /**
+     * Up Method
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-up-method
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->table('email_queue')
+            ->changeColumn('template', 'string', [
+                'limit' => 255,
+            ])
+            ->update();
+    }
+
+    /**
+     * Down Method
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-down-method
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->table('email_queue')
+            ->changeColumn('template', 'string', [
+                'limit' => 50,
+            ])
+            ->update();
+    }
+}

--- a/src/Model/Table/EmailQueueTable.php
+++ b/src/Model/Table/EmailQueueTable.php
@@ -9,12 +9,15 @@ use Cake\I18n\FrozenTime;
 use Cake\ORM\Table;
 use EmailQueue\Database\Type\JsonType;
 use EmailQueue\Database\Type\SerializeType;
+use LengthException;
 
 /**
  * EmailQueue Table.
  */
 class EmailQueueTable extends Table
 {
+    const MAX_TEMPLATE_LENGTH = 100;
+
     /**
      * {@inheritdoc}
      */
@@ -50,10 +53,15 @@ class EmailQueueTable extends Table
      * - config : the name of the email config to be used for sending
      *
      * @throws \Exception any exception raised in transactional callback
+     * @throws LengthException If `template` option length is greater than maximum allowed length
      * @return bool
      */
     public function enqueue($to, array $data, array $options = [])
     {
+        if (strlen($options['template']) > self::MAX_TEMPLATE_LENGTH) {
+            throw new LengthException('`template` length must be less or equal to ' . self::MAX_TEMPLATE_LENGTH);
+        }
+
         $defaults = [
             'subject' => '',
             'send_at' => new FrozenTime('now'),


### PR DESCRIPTION
Length of the column `template` is restricted to 50 chars. This is actually too short and will make email with a longer template path failed to be enqueued. 
It is often that a template path for an email go beyond that limit. For example, while using the plugin syntax in the template.