### PR TITLE
Fix deprecation warning due to missing ->all()

### DIFF
--- a/src/Shell/PreviewShell.php
+++ b/src/Shell/PreviewShell.php
@@ -26,7 +26,7 @@ class PreviewShell extends Shell
         }
 
         $emailQueue = TableRegistry::getTableLocator()->get('EmailQueue', ['className' => EmailQueueTable::class]);
-        $emails = $emailQueue->find()->where($conditions)->toList();
+        $emails = $emailQueue->find()->where($conditions)->all()->toList();
 
         if (!$emails) {
             $this->out('No emails found');


### PR DESCRIPTION
Fixes
```
deprecated: 16384 :: Calling `Cake\Datasource\ResultSetInterface` methods, such as `toList()`, on queries is deprecated. You must call `all()` first (for example, `all()->toList()`).
/srv/app/vendor/lorenzo/cakephp-email-queue/src/Shell/PreviewShell.php, line: 29
```